### PR TITLE
Don't allow start up BrowserSync with production flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var gulp        = require('gulp'),
     browserSync = require('browser-sync'),
     _           = require('underscore'),
     elixir      = require('laravel-elixir');
+    config      = elixir.config;
 
 elixir.extend('browserSync', function (src, options) {
   var defaultSrc = [

--- a/index.js
+++ b/index.js
@@ -18,38 +18,25 @@ elixir.extend('browserSync', function (src, options, onlyTriggerShouldBeWatch) {
     proxy: 'homestead.app'
   }, options);
 
+  // check if task should only be triggered by 'gulp watch'
   var onlyTriggerShouldBeWatch = onlyTriggerShouldBeWatch || true;
 
   gulp.task('browser-sync', function () {
     
     var triggerTask = false;
-    // checks if trigger was 'gulp watch'
+    // checks if trigger is 'gulp watch'
     var taskIsWatch = (gulp.tasks.watch.done == true);
 
-    if (onlyTriggerShouldBeWatch && taskIsWatch) { triggerTask = true; }
-    if (!onlyTriggerShouldBeWatch) { triggerTask = true; }
-
+    if ( ( onlyTriggerShouldBeWatch && taskIsWatch ) || ( !onlyTriggerShouldBeWatch ) ) 
+      { triggerTask = true; }
 
     if (triggerTask)
-    {
-        // checks if trigger was 'gulp watch'
-        if (gulp.tasks.watch.done == true) {
-
-            if (!browserSync.active) {
-              browserSync(options);
-            } else {
-              browserSync.reload();
-            }
-            
-        }  
-    }
-    else
     {
         if (!browserSync.active) {
           browserSync(options);
         } else {
           browserSync.reload();
-        }
+        }       
     }
 
   });

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var gulp        = require('gulp'),
     _           = require('underscore'),
     elixir      = require('laravel-elixir');
 
-elixir.extend('browserSync', function (src, options) {
+elixir.extend('browserSync', function (src, options, onlyTriggerShouldBeWatch) {
   var defaultSrc = [
     'app/**/*',
     'public/**/*',
@@ -18,12 +18,40 @@ elixir.extend('browserSync', function (src, options) {
     proxy: 'homestead.app'
   }, options);
 
+  var onlyTriggerShouldBeWatch = onlyTriggerShouldBeWatch || true;
+
   gulp.task('browser-sync', function () {
-    if (!browserSync.active) {
-      browserSync(options);
-    } else {
-      browserSync.reload();
+    
+    var triggerTask = false;
+    // checks if trigger was 'gulp watch'
+    var taskIsWatch = (gulp.tasks.watch.done == true);
+
+    if (onlyTriggerShouldBeWatch && taskIsWatch) { triggerTask = true; }
+    if (!onlyTriggerShouldBeWatch) { triggerTask = true; }
+
+
+    if (triggerTask)
+    {
+        // checks if trigger was 'gulp watch'
+        if (gulp.tasks.watch.done == true) {
+
+            if (!browserSync.active) {
+              browserSync(options);
+            } else {
+              browserSync.reload();
+            }
+            
+        }  
     }
+    else
+    {
+        if (!browserSync.active) {
+          browserSync(options);
+        } else {
+          browserSync.reload();
+        }
+    }
+
   });
 
   this.registerWatcher('browser-sync', src);

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var gulp        = require('gulp'),
     _           = require('underscore'),
     elixir      = require('laravel-elixir');
 
-elixir.extend('browserSync', function (src, options, onlyTriggerShouldBeWatch) {
+elixir.extend('browserSync', function (src, options) {
   var defaultSrc = [
     'app/**/*',
     'public/**/*',
@@ -18,26 +18,11 @@ elixir.extend('browserSync', function (src, options, onlyTriggerShouldBeWatch) {
     proxy: 'homestead.app'
   }, options);
 
-  // check if task should only be triggered by 'gulp watch'
-  var onlyTriggerShouldBeWatch = onlyTriggerShouldBeWatch || true;
-
   gulp.task('browser-sync', function () {
     
-    var triggerTask = false;
-    // checks if trigger is 'gulp watch'
-    var taskIsWatch = (gulp.tasks.watch.done == true);
-
-    if ( ( onlyTriggerShouldBeWatch && taskIsWatch ) || ( !onlyTriggerShouldBeWatch ) ) 
-      { triggerTask = true; }
-
-    if (triggerTask)
-    {
-        if (!browserSync.active) {
-          browserSync(options);
-        } else {
-          browserSync.reload();
-        }       
-    }
+    // with the production flag BrowserSync aren't allowed to startup
+    if (!config.production && !browserSync.active) { browserSync(options) }
+    if (browserSync.active) { browserSync.reload(); } 
 
   });
 


### PR DESCRIPTION
EDITED: Please look comment below!

I added the possibility to config your elixir extension to trigger the browser-sync event only when `gulp watch` is called via command-line. 

You can activate the feature with a third property in
```
elixir(function(mix) {
    mix.browserSync(src, options, onlyTriggerIsWatch) // true or false, default is false
}
```

These feature is needed when deploying your application with a deploy script at your server. For example by using Laravel Forge. 

After deploying to the production server `gulp` is executed on the server to compile scss, js. 
At the your version of the extension it would start the BrowserSync process too and don't terminate it automatically. You have too SSH-Login to your server and search the process manually and kill it manually..... but there is no use for BrowserSync on the production server.

With my switch you can configure the browsersync-elixir-extension so, that it will be only triggered, when you execute `gulp watch` via the command line in your local environment. Gulp watch is a task, which you don't need at your production server.

Please consider merging.

Thank you in advance! 



Please merge this commit! 